### PR TITLE
Changed read_discon_file file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,5 @@ venv.bak/
 #  Hidding files starting with underscore except init
 _*
 !__init__.py
+*.xml
+*.iml

--- a/openfast_toolbox/io/rosco_discon_file.py
+++ b/openfast_toolbox/io/rosco_discon_file.py
@@ -142,7 +142,7 @@ class ROSCODISCONFile(File):
                         fmtFloat=fmt
                         break
                 if type(v) is str:
-                    sval='"{:15s}"    '.format(v)
+                    sval='"{}"    '.format(v)
                 elif hasattr(v, '__len__'):
                     if isinstance(v[0], (np.floating, float)):
                         sval=' '.join([fmtFloat.format(vi) for vi in v]  )+'    '
@@ -154,7 +154,7 @@ class ROSCODISCONFile(File):
                     sval=fmtFloat.format(v) + '     '
                 else:
                     sval='{} '.format(v)
-                s+='{}{}{}\n'.format(sval, sparam, comment)
+                s+='{:20s}{}{}\n'.format(sval, sparam, comment)
         return s
 
 


### PR DESCRIPTION
I have made changes to the so that it doesn't add any whitespaces in-between strings while writing Rosco .IN file. Earlier it added 15 spaces between"" for strings. Which has problems while re-reading the same .IN file again.  