### PR TITLE
ROSCO input file: write "PerfTableSize" without decimals

### DIFF
--- a/openfast_toolbox/io/rosco_discon_file.py
+++ b/openfast_toolbox/io/rosco_discon_file.py
@@ -136,6 +136,7 @@ class ROSCODISCONFile(File):
                 FMTs['{:<4.4f}']=['WE_FOPoles_v']
                 FMTs['{:<10.8f}']=['WE_FOPoles']
                 FMTs['{:<10.3f}']=['PS_BldPitchMin']
+                FMTs['{:<7.0f}']=['PerfTableSize']
                 fmtFloat='{:<014.5f}'
                 for fmt,keys in FMTs.items():
                     if param in keys:


### PR DESCRIPTION
If I use `ROSCODISCONFile.write()` after reading a working DISCON.IN, the line of the performance table size is written as:

```
20.00000000000 20.00000000000    ! PerfTableSize     - Size of rotor performance tables, first number refers to number of blade pitch angles, second number referse to number of tip-speed ratios
```

Which can't be read by ROSCO (at least version 2.6.0) with error `The "PerfTableSize" array was not assigned valid REAL values on line #90.` I have just modified it to write it without decimals, so the result is the same as the original file:

```
20      20         ! PerfTableSize     - Size of rotor performance tables, first number refers to number of blade pitch angles, second number referse to number of tip-speed ratios
```

Now this can be read and the simulation runs :)
