### PR TITLE
bugfix: for Issue #12 to run pytest, remove __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-"""Initializes the package"""


### PR DESCRIPTION
The issues faced here at [Issue #12](https://github.com/OpenFAST/openfast_toolbox/issues/12 )
- `pytest` command doesn't work out of the box
- suggestion: remove __init__.py from repository root for easier pytest path interpretation
- `pytest` command works now
- 