### PR TITLE
Improve/17.4: Create inflowType, inflowPath spec with options LES, TS replacing LESpath spec.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,0 @@
-"""Initializes the package"""

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+"""Initialize package"""

--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -83,7 +83,7 @@ class FFCaseCreation:
                  nSeeds = 6,
                  seedValues = None,
                  inflowPath = None,
-                 inflowType = 'TS',
+                 inflowType = None,
                  sweepYawMisalignment = False,
                  refTurb_rot = 0,
                  verbose = 0):
@@ -140,8 +140,8 @@ class FFCaseCreation:
         seedValues: list of int
             Seed value for each seed of requested TurbSim simulations if nSeeds!=6
         inflowType: str
-            inflow type (LES or TS) This variable will dictate whether it is a TurbSim-driven or LES-driven case
-            Choose 'LES' or 'TS' (default is TS, TurbSim-driven)
+            Inflow type (LES or TS) This variable will dictate whether it is a TurbSim-driven or LES-driven case
+            Choose 'LES' or 'TS' (no default is set)
         inflowPath: str or list of strings
             Full path of the LES data, if driven by LES. If None, the setup will be for TurbSim inflow.
             inflowPath can be a single path, or a list of paths of the same length as the sweep in conditions.
@@ -249,7 +249,7 @@ class FFCaseCreation:
             s += f'  Path: {self.inflowPath}\n'
         
         
-        if self.TSlowBoxFilesCreatedBool or self.inflowType != 'TS':
+        if self.TSlowBoxFilesCreatedBool or self.inflowType == 'LES':
             s += f'  Low-resolution domain: \n'
             s += f'   - ds low: {self.ds_low_les} m\n'
             s += f'   - dt low: {self.dt_low_les} s\n'
@@ -259,7 +259,7 @@ class FFCaseCreation:
             s += f'Low-res boxes not created yet.\n'
         
         
-        if self.TShighBoxFilesCreatedBool or self.inflowType != 'TS':
+        if self.TShighBoxFilesCreatedBool or self.inflowType == 'LES':
             s += f'  High-resolution domain: \n'
             s += f'   - ds high: {self.ds_high_les} m\n'
             s += f'   - dt high: {self.dt_high_les} s\n'
@@ -423,7 +423,7 @@ class FFCaseCreation:
         if self.inflowType == 'TS':
             self.inflowStr = 'TurbSim'
             self.Mod_AmbWind = 3
-        else:
+        elif self.inflowType == 'LES':
             if isinstance(self.inflowPath,str): self.inflowPath = [self.inflowPath]*len(self.vhub)
             self.inflowStr = 'LES'
             self.Mod_AmbWind = 1
@@ -434,6 +434,8 @@ class FFCaseCreation:
             if None in (self.dt_high_les, self.ds_high_les, self.dt_low_les, self.ds_low_les):
                 raise ValueError (f'An LES-driven case was requested, but one or more grid parameters were not given. '\
                                    'Set `dt_high_les`, `ds_high_les`, `dt_low_les`, and `ds_low_les` based on your LES boxes.')
+        else:
+            raise ValueError (f"Inflow type `inflowType` should be 'TS' or 'LES'. Received {self.inflowType}.")
             
 
         # Check the wake model (1:Polar; 2:Curl; 3:Cartesian)

--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -1640,7 +1640,7 @@ class FFCaseCreation:
         if t is not None:
             options += f'-t {t} '
         if p is not None:
-            otions += f'-p {p} '
+            options += f'-p {p} '
 
         sub_command = f"sbatch {options}{self.slurmfilename_high}"
         print(f'Calling: {sub_command}')
@@ -2193,7 +2193,7 @@ class FFCaseCreation:
                     if t is not None:
                         options += f'-t {t} '
                     if p is not None:
-                        otions += f'-p {p} '
+                        options += f'-p {p} '
 
                     sub_command = f"sbatch {options}{fname}"
                     print(f'Calling: {sub_command}')

--- a/openfast_toolbox/fastfarm/examples/Ex3_FFarmCompleteSetup.py
+++ b/openfast_toolbox/fastfarm/examples/Ex3_FFarmCompleteSetup.py
@@ -78,9 +78,10 @@ def main():
     # ----------- Execution parameters
     ffbin = '/full/path/to/your/binary/.../bin/FAST.Farm'
 
-    # ----------- Inflow type (LES or TS) This variable will dictate whether it is a TurbSim-driven or LES-driven case
-    inflowType = 'TS'  # Choose 'LES' or 'TS' (default is TS, TurbSim-driven)
-    inflowPath =  None # '/full/path/to/TS/or/LES/case' set as None if TurbSim-driven is desired
+    # ----------- Inflow type (LES or TS)
+    inflowType = 'TS'  # Choose 'LES' or 'TS'
+    # If LES, then set the inflowPath below
+    # inflowPath = '/full/path/to/LES/case'
 
     # -----------------------------------------------------------------------------
     # ----------- Template files
@@ -125,9 +126,10 @@ def main():
                           dt_high_les, ds_high_les, extent_high,
                           dt_low_les, ds_low_les, extent_low,
                           ffbin=ffbin, mod_wake=mod_wake, yaw_init=yaw_init,
-                          nSeeds=nSeeds, refTurb_rot=refTurb_rot,
-                          inflowType=inflowType, inflowPath=inflowPath,
-                          verbose=1)
+                          nSeeds=nSeeds,
+                          inflowType=inflowType,
+                          #inflowPath=inflowPath, # if LES, uncomment this line
+                          refTurb_rot=refTurb_rot, verbose=1)
 
     case.setTemplateFilename(templatePath, EDfilename, SEDfilename, HDfilename, SrvDfilename, ADfilename,
                              ADskfilename, SubDfilename, IWfilename, BDfilepath, bladefilename, towerfilename,

--- a/openfast_toolbox/fastfarm/examples/Ex3_FFarmCompleteSetup.py
+++ b/openfast_toolbox/fastfarm/examples/Ex3_FFarmCompleteSetup.py
@@ -126,7 +126,7 @@ def main():
                           dt_low_les, ds_low_les, extent_low,
                           ffbin=ffbin, mod_wake=mod_wake, yaw_init=yaw_init,
                           nSeeds=nSeeds, refTurb_rot=refTurb_rot,
-                          inflowType='LES', inflowPath=inflowPath,
+                          inflowType=inflowType, inflowPath=inflowPath,
                           verbose=1)
 
     case.setTemplateFilename(templatePath, EDfilename, SEDfilename, HDfilename, SrvDfilename, ADfilename,

--- a/openfast_toolbox/fastfarm/examples/Ex3_FFarmCompleteSetup.py
+++ b/openfast_toolbox/fastfarm/examples/Ex3_FFarmCompleteSetup.py
@@ -77,12 +77,11 @@ def main():
     
     # ----------- Execution parameters
     ffbin = '/full/path/to/your/binary/.../bin/FAST.Farm'
-    
-    # ----------- LES parameters. This variable will dictate whether it is a TurbSim-driven or LES-driven case
-    LESpath = '/full/path/to/the/LES/case'
-    #LESpath = None # set as None if TurbSim-driven is desired
-    
-    
+
+    # ----------- Inflow type (LES or TS) This variable will dictate whether it is a TurbSim-driven or LES-driven case
+    inflowType = 'TS'  # Choose 'LES' or 'TS' (default is TS, TurbSim-driven)
+    inflowPath =  None # '/full/path/to/TS/or/LES/case' set as None if TurbSim-driven is desired
+
     # -----------------------------------------------------------------------------
     # ----------- Template files
     templatePath            = '/full/path/where/template/files/are'
@@ -126,7 +125,8 @@ def main():
                           dt_high_les, ds_high_les, extent_high,
                           dt_low_les, ds_low_les, extent_low,
                           ffbin=ffbin, mod_wake=mod_wake, yaw_init=yaw_init,
-                          nSeeds=nSeeds, LESpath=LESpath, refTurb_rot=refTurb_rot,
+                          nSeeds=nSeeds, refTurb_rot=refTurb_rot,
+                          inflowType='LES', inflowPath=inflowPath,
                           verbose=1)
 
     case.setTemplateFilename(templatePath, EDfilename, SEDfilename, HDfilename, SrvDfilename, ADfilename,
@@ -141,7 +141,7 @@ def main():
     case.copyTurbineFilesForEachCase()
 
     # TurbSim setup
-    if LESpath is None:
+    if inflowType == 'TS':
         case.TS_low_setup()
         case.TS_low_slurm_prepare(slurm_TS_low)
         #case.TS_low_slurm_submit()


### PR DESCRIPTION
From [issue](https://github.com/OpenFAST/openfast_toolbox/issues/17) #17 
- partly resolving point number 4 
- Replace the specification of `LESpath` and add a way to specify what type of inflow will be executed (see [here](https://github.com/OpenFAST/openfast_toolbox/blob/a9315c0507175c836d013cc0494109ef2d35b411/pyFAST/fastfarm/examples/Ex3_FFarmCompleteSetup.py#L81-L83)). 
- `inflowType` and `InflowPath` specification added by replacing `LESpath` spec in `FFCaseCreation` class.
- Currently the `inflowType` takes two options `LES` and `TS` (with `TS` as default i.e. TurboSim driven)
- `inflowPath` can be set to None if `inflowType` is `TS`
- Additional configuration logic can be added where indicated for LES or Mann inflows.
