### PR TITLE
Remove supercontroller from FAST.Farm files

### DIFF
--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -2195,10 +2195,6 @@ class FFCaseCreation:
                     #if checkWindFiles:
                     #    ff_file['ChkWndFiles'] = 'TRUE'
         
-                    # Super controller
-                    ff_file['UseSC'] = False
-                    ff_file['SC_FileName'] = '/path/to/SC_DLL.dll'
-
                     # Shared mooring system
                     if self.hasMD and not self.multi_MD:
                         ff_file['Mod_SharedMooring'] = 3  # {0: None, 3=MoorDyn}
@@ -2301,10 +2297,6 @@ class FFCaseCreation:
                     ff_file['Mod_AmbWind'] = self.Mod_AmbWind  # 3: multiple TurbSim
                     ff_file['TMax'] = self.tmax
         
-                    # Super controller
-                    ff_file['UseSC'] = False
-                    ff_file['SC_FileName'] = '/path/to/SC_DLL.dll'
-                    
                     # Shared mooring system
                     if self.hasMD and not self.multi_MD:
                         ff_file['Mod_SharedMooring'] = 3  # {0: None, 3=MoorDyn}

--- a/openfast_toolbox/fastfarm/examples/SampleFiles/TestCase.fstf
+++ b/openfast_toolbox/fastfarm/examples/SampleFiles/TestCase.fstf
@@ -4,10 +4,7 @@ Sample FAST.Farm input file
 False              Echo               Echo input data to <RootName>.ech? (flag)
 FATAL              AbortLevel         Error level when simulation should abort (string) {"WARNING", "SEVERE", "FATAL"}
 2000.0             TMax               Total run time (s) [>=0.0]
-False              UseSC              Use a super controller? (flag)
 2                  Mod_AmbWind        Ambient wind model (-) (switch) {1: high-fidelity precursor in VTK format, 2: InflowWind module}
---- SUPER CONTROLLER --- [used only for UseSC=True]
-"SC_DLL.dll"       SC_FileName        Name/location of the dynamic library {.dll [Windows] or .so [Linux]} containing the Super Controller algorithms (quoated string)
 --- AMBIENT WIND: PRECURSOR IN VTK FORMAT --- [used only for Mod_AmbWind=1]
 2.0                DT_Low-VTK                 Time step for low -resolution wind data input files; will be used as the global FAST.Farm time step (s) [>0.0]
 0.1          DT_High-VTK            Time step for high-resolution wind data input files (s) [>0.0]


### PR DESCRIPTION
SuperController module is being deprecated in OpenFAST ([#2729](https://github.com/OpenFAST/openfast/pull/2729)).
This PR should make OpenFAST_toolbox compatible with the change.