### PR TITLE
Allow space-separated entry by default

### DIFF
--- a/openfast_toolbox/io/fast_input_file.py
+++ b/openfast_toolbox/io/fast_input_file.py
@@ -1130,6 +1130,32 @@ def strIsInt(s):
 def strToBool(s):
     return s.lower() in ['true','t']
 
+def addToList(l,value):
+    if l is None:
+        l = value
+    elif isinstance(l,int):
+        if strIsInt(value):
+            l = [l, value]
+    elif isinstance(l,float):
+        if strIsFloat(value):
+            l = [l, value]
+    elif isinstance(l,str):
+        if isStr(value):
+            l = [l, value]
+    elif isinstance(l,bool):
+        if strIsBool(value):
+            l = [l, value]
+    else:
+        if   isinstance(l[0],int)   and strIsInt(value):
+                l.append(value)
+        elif isinstance(l[0],float) and strIsFloat(value):
+                l.append(value)
+        elif isinstance(l[0],str)   and isStr(value):
+                l.append(value)
+        elif isinstance(l[0],bool)  and strIsBool(value):
+                l.append(value)
+    return l
+
 def hasSpecialChars(s):
     # fast allows for parenthesis
     # For now we allow for - but that's because of BeamDyn geometry members 
@@ -1235,17 +1261,22 @@ def parseFASTInputLine(line_raw,i,allowSpaceSeparatedList=False):
             _merge_value(splits)
             s=splits[0]
 
-            if strIsInt(s):
-                d['value']=int(s)
-                if allowSpaceSeparatedList and len(splits)>1:
-                    if strIsInt(splits[1]):
-                        d['value']=splits[0]+ ' '+splits[1]
-            elif strIsFloat(s):
-                d['value']=float(s)
-            elif strIsBool(s):
-                d['value']=strToBool(s)
-            else:
-                d['value']=s
+            # The loop below assumes allowSpaceSeparatedList is true
+            allowSpaceSeparatedList = True
+
+            for s in splits:
+                if strIsInt(s):
+                    d['value'] = addToList(d['value'],int(s))
+                elif strIsFloat(s):
+                    d['value'] = addToList(d['value'],float(s))
+                elif strIsBool(s):
+                    d['value'] = addToList(d['value'],strToBool(s))
+                else:
+                    d['value'] = addToList(d['value'], s)
+                    # For strings, only the first one should be printed
+                    break
+                if not allowSpaceSeparatedList:
+                    break
             iNext=1
 
         # Extracting label (TODO, for now only second split)


### PR DESCRIPTION
Issue pointed out on the forums: https://forums.nrel.gov/t/the-rotorapexoffsetpos-array-was-not-assigned-valid-real-values-on-line-59-issue-with-openfast-toolbox/8616

The issue is reproducible and is occurring with entry `RotorApexOffsetPos` that has 3 components. Only the first one is being read since by default the toolbox is not accepting space-separated entries:
https://github.com/OpenFAST/openfast_toolbox/blob/2553643f6c8530e247bfd21d99f36efdfad2e3c0/openfast_toolbox/io/fast_input_file.py#L475

This PR changes that behavior, even though I'm not directly changing the variable `allowSpaceSeparatedList` in the line above. Now, for every line, we read as many space-separated consecutive scalars and bools as possible. Strings are still only read once. The prior implementation only read _two_ integers when `allowSpaceSeparatedList` is set to True:
https://github.com/OpenFAST/openfast_toolbox/blob/2553643f6c8530e247bfd21d99f36efdfad2e3c0/openfast_toolbox/io/fast_input_file.py#L1240-L1242
Such restriction is now lifted.

The goal with the change is that when the user reads a file using `f = FASTInputFile('my_openfast_input.dat')` and then writes it again with `f.write('my_openfast_input_mod.dat')`, no changes are introduced. 

There is one detail:
Now when the user specifies extra inputs because he/she knows OpenFAST will not read them, e.g. `2 3 WindType <comments>`, then the toolbox will in fact read both and re-write them as `2, 3 WindType <comments>`. The new written file will still be read by OpenFAST normally, only taking into account the first value. However, some processing scripts might have checks like `f['WindType']==2` and that would fail.
