### PR TITLE
Add bash scripts

### DIFF
--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -1677,7 +1677,7 @@ class FFCaseCreation:
             filename  = sed_split[-1]
             sed_split = f'sed ' + ' '.join(sed_split[2:]) + f"> {os.path.join(self.path, 'temp.txt')}"
             _ = subprocess.call(sed_split, cwd=self.path, shell=True)
-            shutil.move(os.path.join(self.path,'temp.txt'), f"{filename}_mod")
+            shutil.move(os.path.join(self.path,'temp.txt'), filename)
 
 
     def TS_low_slurm_prepare(self, slurmfilepath, inplace=True):

--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -1664,13 +1664,13 @@ class FFCaseCreation:
         self.TSlowBoxFilesCreatedBool = True
 
 
-    def sed_inplace(self, sed_command, sed_inplace):
+    def sed_inplace(self, sed_command, inplace):
         '''
         sed in place does not work on standard input. A workaround here
         is to save to another file and then copy over
         '''
 
-        if sed_inplace:
+        if inplace:
             _ = subprocess.call(sed_command, cwd=self.path, shell=True)
         else:
             sed_split = sed_command.split(' ')
@@ -1680,7 +1680,7 @@ class FFCaseCreation:
             shutil.move(os.path.join(self.path,'temp.txt'), f"{filename}_mod")
 
 
-    def TS_low_slurm_prepare(self, slurmfilepath, sed_inplace=True):
+    def TS_low_slurm_prepare(self, slurmfilepath, inplace=True):
 
         # --------------------------------------------------
         # ----- Prepare SLURM script for Low-res boxes -----
@@ -1697,35 +1697,35 @@ class FFCaseCreation:
 
         # Change job name (for convenience only)
         sed_command = f"sed -i 's|^#SBATCH --job-name=lowBox|#SBATCH --job-name=lowBox_{os.path.basename(self.path)}|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change logfile name (for convenience only)
         sed_command = f"sed -i 's|#SBATCH --output log.lowBox|#SBATCH --output log.turbsim_low|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change memory per cpu
         sed_command = f"sed -i 's|--mem-per-cpu=25000M|--mem-per-cpu={memory_per_cpu}M|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change number of nodes values 
         sed_command = f"sed -i 's|^#SBATCH --nodes.*|#SBATCH --nodes={int(np.ceil(self.nConditions*self.nSeeds/6))}|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change the fastfarm binary to be called
         sed_command = f"""sed -i "s|^turbsimbin.*|turbsimbin='{self.tsbin}'|g" {self.slurmfilename_low}"""
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change the path inside the script to the desired one
         sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {self.slurmfilename_low}"""
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Assemble list of conditions and write it
         listtoprint = "' '".join(self.condDirList)
         sed_command = f"""sed -i "s|^condList.*|condList=('{listtoprint}')|g" {self.slurmfilename_low}"""
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change the number of seeds
         sed_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
 
         if self.nSeeds > 6:
             print(f'--- WARNING: The memory-per-cpu on the low-res boxes SLURM script might be too low given {self.nSeeds} seeds.')
 
 
-    def TS_low_slurm_submit(self, qos='normal', A=None, t=None, p=None):
+    def TS_low_slurm_submit(self, qos='normal', A=None, t=None, p=None, inplace=True):
         # ---------------------------------
         # ----- Run turbSim Low boxes -----
         # ---------------------------------
@@ -1740,7 +1740,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_low}"
         print(f'Calling: {sub_command}')
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
 
 
     def TS_low_createSymlinks(self):
@@ -1968,7 +1968,7 @@ class FFCaseCreation:
         self.TShighBoxFilesCreatedBool = True
         
 
-    def TS_high_slurm_prepare(self, slurmfilepath):
+    def TS_high_slurm_prepare(self, slurmfilepath, inplace=True):
         # ---------------------------------------------------
         # ----- Prepare SLURM script for High-res boxes -----
         # ---------------------------------------------------
@@ -1982,38 +1982,38 @@ class FFCaseCreation:
         
         # Change job name (for convenience only)
         sed_command = f"sed -i 's|^#SBATCH --job-name.*|#SBATCH --job-name=highBox_{os.path.basename(self.path)}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change logfile name (for convenience only)
         sed_command = f"sed -i 's|#SBATCH --output log.highBox|#SBATCH --output log.turbsim_high|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change number of nodes values
         sed_command = f"sed -i 's|^#SBATCH --nodes.*|#SBATCH --nodes={int(np.ceil(ntasks/36))}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change the fastfarm binary to be called
         sed_command = f"""sed -i "s|^turbsimbin.*|turbsimbin='{self.tsbin}'|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change the path inside the script to the desired one
         sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change number of turbines
         sed_command = f"sed -i 's|^nTurbines.*|nTurbines={self.nTurbines}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Change number of seeds
         set_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Assemble list of conditions and write it
         listtoprint = "' '".join(self.condDirList)
         sed_command = f"""sed -i "s|^condList.*|condList=('{listtoprint}')|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
         # Assemble list of cases and write it
         highBoxesCaseDirList = [self.caseDirList[c] for c in self.allHighBoxCases.case.values]
         listtoprint = "' '".join(highBoxesCaseDirList)
         sed_command = f"""sed -i "s|^caseList.*|caseList=('{listtoprint}')|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
 
 
 
-    def TS_high_slurm_submit(self, qos='normal', A=None, t=None, p=None):
+    def TS_high_slurm_submit(self, qos='normal', A=None, t=None, p=None, inplace=True):
         # ----------------------------------
         # ----- Run turbSim High boxes -----
         # ----------------------------------
@@ -2028,7 +2028,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_high}"
         print(f'Calling: {sub_command}')
-        sed_inplace(sed_command, sed_inplace)
+        sed_inplace(sed_command, inplace)
 
     
     def TS_high_create_symlink(self):
@@ -2535,7 +2535,7 @@ class FFCaseCreation:
 
 
 
-    def FF_slurm_prepare(self, slurmfilepath):
+    def FF_slurm_prepare(self, slurmfilepath, inplace=True):
         # ----------------------------------------------
         # ----- Prepare SLURM script for FAST.Farm -----
         # ------------- ONE SCRIPT PER CASE ------------
@@ -2555,32 +2555,32 @@ class FFCaseCreation:
         
                     # Change job name (for convenience only)
                     sed_command = f"sed -i 's|#SBATCH --job-name=runFF|#SBATCH --job-name=c{cond}_c{case}_s{seed}_runFF_{os.path.basename(self.path)}|g' {fname}"
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     # Change logfile name (for convenience only)
                     sed_command = f"sed -i 's|#SBATCH --output log.fastfarm_c0_c0_seed0|#SBATCH --output log.fastfarm_c{cond}_c{case}_s{seed}|g' {fname}"
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     # Change the fastfarm binary to be called
                     sed_command = f"""sed -i "s|^fastfarmbin.*|fastfarmbin='{self.ffbin}'|g" {fname}"""
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     # Change the path inside the script to the desired one
                     sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {fname}"""
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     # Write condition
                     sed_command = f"""sed -i "s|^cond.*|cond='{self.condDirList[cond]}'|g" {fname}"""
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     # Write case
                     sed_command = f"""sed -i "s|^case.*|case='{self.caseDirList[case]}'|g" {fname}"""
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     # Write seed
                     sed_command = f"""sed -i "s|^seed.*|seed={seed}|g" {fname}"""
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     # Wirte FAST.Farm filename
                     sed_command = f"""sed -i "s/FFarm_mod.fstf/FF.fstf/g" {fname}"""
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
 
 
 
-    def FF_slurm_submit(self, qos='normal', A=None, t=None, p=None, delay=4):
+    def FF_slurm_submit(self, qos='normal', A=None, t=None, p=None, delay=4, inplace=True):
 
         # ----------------------------------
         # ---------- Run FAST.Farm ---------
@@ -2605,7 +2605,7 @@ class FFCaseCreation:
 
                     sub_command = f"sbatch {options}{fname}"
                     print(f'Calling: {sub_command}')
-                    sed_inplace(sed_command, sed_inplace)
+                    sed_inplace(sed_command, inplace)
                     time.sleep(delay) # Sometimes the same job gets submitted twice. This gets around it.
 
 # ----------------------------------------------

--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -1677,7 +1677,7 @@ class FFCaseCreation:
             filename  = sed_split[-1]
             sed_split = f'sed ' + ' '.join(sed_split[2:]) + f"> {os.path.join(self.path, 'temp.txt')}"
             _ = subprocess.call(sed_split, cwd=self.path, shell=True)
-            shutil.move(os.path.join(self.path,'temp.txt'), filename)
+            shutil.move(os.path.join(self.path,'temp.txt'), os.path.join(self.path,filename))
 
 
     def TS_low_slurm_prepare(self, slurmfilepath, inplace=True):
@@ -1740,7 +1740,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_low}"
         print(f'Calling: {sub_command}')
-        self.sed_inplace(sed_command, inplace)
+        self.sed_inplace(sub_command, inplace)
 
 
     def TS_low_createSymlinks(self):
@@ -1999,7 +1999,7 @@ class FFCaseCreation:
         sed_command = f"sed -i 's|^nTurbines.*|nTurbines={self.nTurbines}|g' {self.slurmfilename_high}"
         self.sed_inplace(sed_command, inplace)
         # Change number of seeds
-        set_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_high}"
+        sed_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_high}"
         self.sed_inplace(sed_command, inplace)
         # Assemble list of conditions and write it
         listtoprint = "' '".join(self.condDirList)
@@ -2028,7 +2028,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_high}"
         print(f'Calling: {sub_command}')
-        self.sed_inplace(sed_command, inplace)
+        self.sed_inplace(sub_command, inplace)
 
     
     def TS_high_create_symlink(self):
@@ -2605,7 +2605,7 @@ class FFCaseCreation:
 
                     sub_command = f"sbatch {options}{fname}"
                     print(f'Calling: {sub_command}')
-                    self.sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sub_command, inplace)
                     time.sleep(delay) # Sometimes the same job gets submitted twice. This gets around it.
 
 # ----------------------------------------------

--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -1697,29 +1697,29 @@ class FFCaseCreation:
 
         # Change job name (for convenience only)
         sed_command = f"sed -i 's|^#SBATCH --job-name=lowBox|#SBATCH --job-name=lowBox_{os.path.basename(self.path)}|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change logfile name (for convenience only)
         sed_command = f"sed -i 's|#SBATCH --output log.lowBox|#SBATCH --output log.turbsim_low|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change memory per cpu
         sed_command = f"sed -i 's|--mem-per-cpu=25000M|--mem-per-cpu={memory_per_cpu}M|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change number of nodes values 
         sed_command = f"sed -i 's|^#SBATCH --nodes.*|#SBATCH --nodes={int(np.ceil(self.nConditions*self.nSeeds/6))}|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change the fastfarm binary to be called
         sed_command = f"""sed -i "s|^turbsimbin.*|turbsimbin='{self.tsbin}'|g" {self.slurmfilename_low}"""
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change the path inside the script to the desired one
         sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {self.slurmfilename_low}"""
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Assemble list of conditions and write it
         listtoprint = "' '".join(self.condDirList)
         sed_command = f"""sed -i "s|^condList.*|condList=('{listtoprint}')|g" {self.slurmfilename_low}"""
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change the number of seeds
         sed_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_low}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
 
         if self.nSeeds > 6:
             print(f'--- WARNING: The memory-per-cpu on the low-res boxes SLURM script might be too low given {self.nSeeds} seeds.')
@@ -1740,7 +1740,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_low}"
         print(f'Calling: {sub_command}')
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
 
 
     def TS_low_createSymlinks(self):
@@ -1982,34 +1982,34 @@ class FFCaseCreation:
         
         # Change job name (for convenience only)
         sed_command = f"sed -i 's|^#SBATCH --job-name.*|#SBATCH --job-name=highBox_{os.path.basename(self.path)}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change logfile name (for convenience only)
         sed_command = f"sed -i 's|#SBATCH --output log.highBox|#SBATCH --output log.turbsim_high|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change number of nodes values
         sed_command = f"sed -i 's|^#SBATCH --nodes.*|#SBATCH --nodes={int(np.ceil(ntasks/36))}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change the fastfarm binary to be called
         sed_command = f"""sed -i "s|^turbsimbin.*|turbsimbin='{self.tsbin}'|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change the path inside the script to the desired one
         sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change number of turbines
         sed_command = f"sed -i 's|^nTurbines.*|nTurbines={self.nTurbines}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Change number of seeds
         set_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_high}"
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Assemble list of conditions and write it
         listtoprint = "' '".join(self.condDirList)
         sed_command = f"""sed -i "s|^condList.*|condList=('{listtoprint}')|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
         # Assemble list of cases and write it
         highBoxesCaseDirList = [self.caseDirList[c] for c in self.allHighBoxCases.case.values]
         listtoprint = "' '".join(highBoxesCaseDirList)
         sed_command = f"""sed -i "s|^caseList.*|caseList=('{listtoprint}')|g" {self.slurmfilename_high}"""
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
 
 
 
@@ -2028,7 +2028,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_high}"
         print(f'Calling: {sub_command}')
-        sed_inplace(sed_command, inplace)
+        self.sed_inplace(sed_command, inplace)
 
     
     def TS_high_create_symlink(self):
@@ -2555,28 +2555,28 @@ class FFCaseCreation:
         
                     # Change job name (for convenience only)
                     sed_command = f"sed -i 's|#SBATCH --job-name=runFF|#SBATCH --job-name=c{cond}_c{case}_s{seed}_runFF_{os.path.basename(self.path)}|g' {fname}"
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     # Change logfile name (for convenience only)
                     sed_command = f"sed -i 's|#SBATCH --output log.fastfarm_c0_c0_seed0|#SBATCH --output log.fastfarm_c{cond}_c{case}_s{seed}|g' {fname}"
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     # Change the fastfarm binary to be called
                     sed_command = f"""sed -i "s|^fastfarmbin.*|fastfarmbin='{self.ffbin}'|g" {fname}"""
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     # Change the path inside the script to the desired one
                     sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {fname}"""
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     # Write condition
                     sed_command = f"""sed -i "s|^cond.*|cond='{self.condDirList[cond]}'|g" {fname}"""
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     # Write case
                     sed_command = f"""sed -i "s|^case.*|case='{self.caseDirList[case]}'|g" {fname}"""
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     # Write seed
                     sed_command = f"""sed -i "s|^seed.*|seed={seed}|g" {fname}"""
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     # Wirte FAST.Farm filename
                     sed_command = f"""sed -i "s/FFarm_mod.fstf/FF.fstf/g" {fname}"""
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
 
 
 
@@ -2605,7 +2605,7 @@ class FFCaseCreation:
 
                     sub_command = f"sbatch {options}{fname}"
                     print(f'Calling: {sub_command}')
-                    sed_inplace(sed_command, inplace)
+                    self.sed_inplace(sed_command, inplace)
                     time.sleep(delay) # Sometimes the same job gets submitted twice. This gets around it.
 
 # ----------------------------------------------

--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -1084,8 +1084,8 @@ class FFCaseCreation:
         self.EDtowerfilename = "unused";  self.EDtowerfilepath = "unused"
         self.ADbladefilename = "unused";  self.ADbladefilepath = "unused"
         self.turbfilename    = "unused";  self.turbfilepath  = "unused"
+        self.controllerInputfilename = "unused"; self.controllerInputfilepath = "unused"
         self.libdisconfilepath       = "unused"
-        self.controllerInputfilename = "unused"
         self.coeffTablefilename      = "unused"
         self.hydroDatapath           = "unused"
         self.turbsimLowfilepath      = "unused"
@@ -1663,7 +1663,24 @@ class FFCaseCreation:
 
         self.TSlowBoxFilesCreatedBool = True
 
-    def TS_low_slurm_prepare(self, slurmfilepath):
+
+    def sed_inplace(self, sed_command, sed_inplace):
+        '''
+        sed in place does not work on standard input. A workaround here
+        is to save to another file and then copy over
+        '''
+
+        if sed_inplace:
+            _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        else:
+            sed_split = sed_command.split(' ')
+            filename  = sed_split[-1]
+            sed_split = f'sed ' + ' '.join(sed_split[2:]) + f"> {os.path.join(self.path, 'temp.txt')}"
+            _ = subprocess.call(sed_split, cwd=self.path, shell=True)
+            shutil.move(os.path.join(self.path,'temp.txt'), f"{filename}_mod")
+
+
+    def TS_low_slurm_prepare(self, slurmfilepath, sed_inplace=True):
 
         # --------------------------------------------------
         # ----- Prepare SLURM script for Low-res boxes -----
@@ -1680,29 +1697,29 @@ class FFCaseCreation:
 
         # Change job name (for convenience only)
         sed_command = f"sed -i 's|^#SBATCH --job-name=lowBox|#SBATCH --job-name=lowBox_{os.path.basename(self.path)}|g' {self.slurmfilename_low}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change logfile name (for convenience only)
         sed_command = f"sed -i 's|#SBATCH --output log.lowBox|#SBATCH --output log.turbsim_low|g' {self.slurmfilename_low}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change memory per cpu
         sed_command = f"sed -i 's|--mem-per-cpu=25000M|--mem-per-cpu={memory_per_cpu}M|g' {self.slurmfilename_low}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change number of nodes values 
         sed_command = f"sed -i 's|^#SBATCH --nodes.*|#SBATCH --nodes={int(np.ceil(self.nConditions*self.nSeeds/6))}|g' {self.slurmfilename_low}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change the fastfarm binary to be called
         sed_command = f"""sed -i "s|^turbsimbin.*|turbsimbin='{self.tsbin}'|g" {self.slurmfilename_low}"""
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change the path inside the script to the desired one
         sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {self.slurmfilename_low}"""
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Assemble list of conditions and write it
         listtoprint = "' '".join(self.condDirList)
         sed_command = f"""sed -i "s|^condList.*|condList=('{listtoprint}')|g" {self.slurmfilename_low}"""
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change the number of seeds
         sed_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_low}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
 
         if self.nSeeds > 6:
             print(f'--- WARNING: The memory-per-cpu on the low-res boxes SLURM script might be too low given {self.nSeeds} seeds.')
@@ -1723,7 +1740,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_low}"
         print(f'Calling: {sub_command}')
-        _ = subprocess.call(sub_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
 
 
     def TS_low_createSymlinks(self):
@@ -1965,34 +1982,34 @@ class FFCaseCreation:
         
         # Change job name (for convenience only)
         sed_command = f"sed -i 's|^#SBATCH --job-name.*|#SBATCH --job-name=highBox_{os.path.basename(self.path)}|g' {self.slurmfilename_high}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change logfile name (for convenience only)
         sed_command = f"sed -i 's|#SBATCH --output log.highBox|#SBATCH --output log.turbsim_high|g' {self.slurmfilename_high}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change number of nodes values
         sed_command = f"sed -i 's|^#SBATCH --nodes.*|#SBATCH --nodes={int(np.ceil(ntasks/36))}|g' {self.slurmfilename_high}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change the fastfarm binary to be called
         sed_command = f"""sed -i "s|^turbsimbin.*|turbsimbin='{self.tsbin}'|g" {self.slurmfilename_high}"""
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change the path inside the script to the desired one
         sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {self.slurmfilename_high}"""
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change number of turbines
         sed_command = f"sed -i 's|^nTurbines.*|nTurbines={self.nTurbines}|g' {self.slurmfilename_high}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Change number of seeds
         set_command = f"sed -i 's|^nSeeds.*|nSeeds={self.nSeeds}|g' {self.slurmfilename_high}"
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Assemble list of conditions and write it
         listtoprint = "' '".join(self.condDirList)
         sed_command = f"""sed -i "s|^condList.*|condList=('{listtoprint}')|g" {self.slurmfilename_high}"""
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
         # Assemble list of cases and write it
         highBoxesCaseDirList = [self.caseDirList[c] for c in self.allHighBoxCases.case.values]
         listtoprint = "' '".join(highBoxesCaseDirList)
         sed_command = f"""sed -i "s|^caseList.*|caseList=('{listtoprint}')|g" {self.slurmfilename_high}"""
-        _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
 
 
 
@@ -2011,7 +2028,7 @@ class FFCaseCreation:
 
         sub_command = f"sbatch {options}{self.slurmfilename_high}"
         print(f'Calling: {sub_command}')
-        _ = subprocess.call(sub_command, cwd=self.path, shell=True)
+        sed_inplace(sed_command, sed_inplace)
 
     
     def TS_high_create_symlink(self):
@@ -2538,28 +2555,28 @@ class FFCaseCreation:
         
                     # Change job name (for convenience only)
                     sed_command = f"sed -i 's|#SBATCH --job-name=runFF|#SBATCH --job-name=c{cond}_c{case}_s{seed}_runFF_{os.path.basename(self.path)}|g' {fname}"
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     # Change logfile name (for convenience only)
                     sed_command = f"sed -i 's|#SBATCH --output log.fastfarm_c0_c0_seed0|#SBATCH --output log.fastfarm_c{cond}_c{case}_s{seed}|g' {fname}"
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     # Change the fastfarm binary to be called
                     sed_command = f"""sed -i "s|^fastfarmbin.*|fastfarmbin='{self.ffbin}'|g" {fname}"""
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     # Change the path inside the script to the desired one
                     sed_command = f"""sed -i "s|^basepath.*|basepath='{self.path}'|g" {fname}"""
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     # Write condition
                     sed_command = f"""sed -i "s|^cond.*|cond='{self.condDirList[cond]}'|g" {fname}"""
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     # Write case
                     sed_command = f"""sed -i "s|^case.*|case='{self.caseDirList[case]}'|g" {fname}"""
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     # Write seed
                     sed_command = f"""sed -i "s|^seed.*|seed={seed}|g" {fname}"""
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     # Wirte FAST.Farm filename
                     sed_command = f"""sed -i "s/FFarm_mod.fstf/FF.fstf/g" {fname}"""
-                    _ = subprocess.call(sed_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
 
 
 
@@ -2588,7 +2605,7 @@ class FFCaseCreation:
 
                     sub_command = f"sbatch {options}{fname}"
                     print(f'Calling: {sub_command}')
-                    _ = subprocess.call(sub_command, cwd=self.path, shell=True)
+                    sed_inplace(sed_command, sed_inplace)
                     time.sleep(delay) # Sometimes the same job gets submitted twice. This gets around it.
 
 # ----------------------------------------------

--- a/openfast_toolbox/fastfarm/examples/SampleFiles/runAllHighBox_nonHPC.sh
+++ b/openfast_toolbox/fastfarm/examples/SampleFiles/runAllHighBox_nonHPC.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+source $HOME/.bash_profile
+
+# ********************************** USER INPUT ********************************** #
+turbsimbin='/full/path/to/your/binary/.../bin/turbsim'
+basepath='/full/path/to/your/case/dir'
+
+condList=('Cond00_v08.6_PL0.2_TI10' 'Cond01_v10.6_PL0.2_TI10' 'Cond02_v12.6_PL0.2_TI10')
+
+caseList=('Case00_wdirp00_WSfalse_YMfalse' 'Case01_wdirp00_WStrue_YMfalse')
+
+nSeeds=6
+nTurbines=12
+# ******************************************************************************** #
+
+for cond in ${condList[@]}; do
+    for case in ${caseList[@]}; do
+        for ((seed=0; seed<$nSeeds; seed++)); do
+            for ((t=1; t<=$nTurbines; t++)); do
+                dir=$(printf "%s/%s/%s/Seed_%01d/TurbSim" $basepath $cond $case $seed)
+                echo "Submitting $dir/HighT$t.inp"
+                $turbsimbin $dir/HighT$t.inp > $dir/log.hight$t.seed$seed.txt 2>&1 &
+                sleep 0.1
+            done
+        done
+    done
+done
+
+wait
+

--- a/openfast_toolbox/fastfarm/examples/SampleFiles/runAllLowBox_nonHPC.sh
+++ b/openfast_toolbox/fastfarm/examples/SampleFiles/runAllLowBox_nonHPC.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source $HOME/.bash_profile
+
+# ********************************** USER INPUT ********************************** #
+turbsimbin='/full/path/to/your/binary/.../bin/turbsim'
+basepath='/full/path/to/your/case/dir'
+
+condList=('Cond00_v08.6_PL0.2_TI10' 'Cond01_v10.6_PL0.2_TI10' 'Cond02_v12.6_PL0.2_TI10')
+
+nSeeds=6
+# ******************************************************************************** #
+
+for cond in ${condList[@]}; do
+    for((seed=0; seed<$nSeeds; seed++)); do
+       dir=$(printf "%s/%s/Seed_%01d" $basepath $cond $seed)
+       echo "Running $dir/Low.inp"
+       $turbsimbin $dir/Low.inp > $dir/log.low.seed$seed.txt 2>&1 &
+   done
+done
+
+wait
+

--- a/openfast_toolbox/fastfarm/examples/SampleFiles/runFASTFarm_cond0_case0_seed0_nonHPC.sh
+++ b/openfast_toolbox/fastfarm/examples/SampleFiles/runFASTFarm_cond0_case0_seed0_nonHPC.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source $HOME/.bash_profile
+
+# ********************************** USER INPUT ********************************** #
+fastfarmbin='/full/path/to/your/binary/.../bin/FAST.Farm'
+basepath='/full/path/to/your/case/dir'
+
+cond='Cond00_v08.6_TI10'
+case='Case00_wdirp00'
+seed=0
+# ******************************************************************************** #
+
+dir=$(printf "%s/%s/%s/Seed_%01d" $basepath $cond $case $seed)
+cd $dir
+export OMP_STACKSIZE="32 M"
+echo "Running $dir/FFarm_mod.fstf with OMP_STACKSIZE=32M"
+$fastfarmbin $dir/FFarm_mod.fstf > $dir/log.fastfarm.seed$seed.txt 2>&1
+

--- a/openfast_toolbox/fastfarm/postpro/ff_postpro.py
+++ b/openfast_toolbox/fastfarm/postpro/ff_postpro.py
@@ -71,11 +71,11 @@ def readTurbineOutputPar(caseobj, dt_openfast, dt_processing, saveOutput=True, o
     outputnc   = os.path.join(caseobj.path, ncfile)
 
     if output=='zarr' and os.path.isdir(outputzarr) and saveOutput:
-       print(f'Output file {zarrstore} exists. Loading it..')
+       print(f'Output file {zarrstore} exists. Loading it.')
        comb_ds = xr.open_zarr(outputzarr)
        return comb_ds
     if output=='nc' and os.path.isfile(outputnc) and saveOutput:
-       print(f'Output file {ncfile} exists. Loading it..')
+       print(f'Output file {ncfile} exists. Loading it.')
        comb_ds = xr.open_dataset(outputnc)
        return comb_ds
         
@@ -440,7 +440,7 @@ def readFFPlanes(caseobj, slicesToRead=['x','y','z'], verbose=False, saveOutput=
             if len(slicesToRead) > 1:
                 print(f"!! WARNING: Asked for multiple slices. Returning only the first one, {slices}\n",
                       f"           To load other slices, request `slicesToRead='y'`")
-            print(f'Processed output for slice {slices} found. Loading it.')
+            print(f'Processed output file {outputfile} for slice {slices} exists. Loading it.')
             # Data already processed. Reading output
             Slices = xr.open_zarr(outputfile)
             return Slices
@@ -449,7 +449,7 @@ def readFFPlanes(caseobj, slicesToRead=['x','y','z'], verbose=False, saveOutput=
             if len(slicesToRead) > 1:
                 print(f"!! WARNING: Asked for multiple slices. Returning only the first one, {slices}\n",
                       f"           To load other slices, request `slicesToRead='y'`")
-            print(f'Processed output for slice {slices} found. Loading it.')
+            print(f'Processed output file {outputfile} for slice {slices} exists. Loading it.')
             # Data already processed. Reading output
             Slices = xr.open_dataset(outputfile)
             return Slices


### PR DESCRIPTION
Add bash scripts for use on non-HPC machines. Fixes an issue with `sed` on some OSes (`sed` shipped with MacOS for example takes the `-i` argument at the end). Now `sed`s are no longer in place and there is always a temporary file being created. Compatible with `sed` and `gsed`.