### PR TITLE
Adding platform phi angle when plotting the rotors in FFCaseCreation.plot method

### DIFF
--- a/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
+++ b/openfast_toolbox/fastfarm/FASTFarmCaseCreation.py
@@ -2750,11 +2750,12 @@ class FFCaseCreation:
 
                 # plot turbine disk accoding to all yaws in current wdir
                 allyaw_currwdir = self.allCases.where(self.allCases['inflow_deg']==inflow,drop=True).sel(turbine=currTurbine)['yaw']
+                phi             = self.allCases.where(self.allCases['inflow_deg']==inflow,drop=True).sel(turbine=currTurbine)['phi']
                 _, ind = np.unique(allyaw_currwdir, axis=0, return_index=True)
                 yaw_currwdir = allyaw_currwdir[np.sort(ind)].values # duplicates removed, same order as original array
                 for yaw in yaw_currwdir:
-                    ax.plot([dst.x.values-(dst.D.values/2)*sind(yaw), dst.x.values+(dst.D.values/2)*sind(yaw)],
-                            [dst.y.values-(dst.D.values/2)*cosd(yaw), dst.y.values+(dst.D.values/2)*cosd(yaw)], c=color, alpha=alphas[j])
+                    ax.plot([dst.x.values-(dst.D.values/2)*sind(yaw+phi), dst.x.values+(dst.D.values/2)*sind(yaw+phi)],
+                            [dst.y.values-(dst.D.values/2)*cosd(yaw+phi), dst.y.values+(dst.D.values/2)*cosd(yaw+phi)], c=color, alpha=alphas[j])
 
             # plot convex hull of farm (or line) for given inflow
             turbs = self.wts_rot_ds.sel(inflow_deg=inflow)[['x','y']].to_array().transpose()


### PR DESCRIPTION
For floating systems, the yaw value of the platform must be added to the angle when we are plotting the rotors during box plotting. 

Before, if platforms have non-zero phi values, their orientation looks like this:
<img width="923" alt="Screenshot 2025-04-22 at 11 34 06 AM" src="https://github.com/user-attachments/assets/3d650ea1-74c3-44f1-8954-0626ba8fd517" />

After this fix, they will have the correct orientation:
<img width="886" alt="Screenshot 2025-04-22 at 11 33 25 AM" src="https://github.com/user-attachments/assets/ad09fc9c-f626-4d5f-ab5e-cbff748b977b" />
