### PR TITLE
Test Bug Fix, fix variable name for TipRad in Example_EditOpenFASTMod…

### DIFF
--- a/openfast_toolbox/io/examples/Example_EditOpenFASTModel.py
+++ b/openfast_toolbox/io/examples/Example_EditOpenFASTModel.py
@@ -30,7 +30,7 @@ print('> Keys:',ED.keys())
 print('> Hub radius: ',ED['HubRad'])
 print('> Tip radius: ',ED['TipRad'])
 print('> Hub mass:   ',ED['HubMass'])
-ED['TipRadius'] = 64 # Modifying the data
+ED['TipRad'] = 64 # Modifying the data
 #ED.write('_NewFile.dat') # write a new file with modified data
 
 


### PR DESCRIPTION
This pull request addresses a bug in the `Example_EditOpenFASTModel.py` script where an incorrect variable name was used.
The script previously used `TipRadius` when the correct variable name for the blade tip radius is `TipRad`. This could lead to errors or unexpected behavior when the script is executed as part of a test or as an example.

Changes Made:

* In `Example_EditOpenFASTModel.py`, the variable name `TipRadius` has been corrected to `TipRad`.

This change ensures that the script references the correct variable, allowing the associated test or example to function as intended.