### PR TITLE
Enabling pip install from remote repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 import os
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -28,7 +28,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Version Control :: Git",
     ],
-    packages=["openfast_toolbox"],
+    packages=find_packages(),
     python_requires=">=3.6",
     install_requires=[
         "matplotlib",


### PR DESCRIPTION
Fix addresses https://github.com/OpenFAST/openfast_toolbox/issues/13 and is a partial copy of 7ec9a37198c0239fc58ffe882de58838c3639bab. 

The original pull request https://github.com/OpenFAST/openfast_toolbox/pull/25 that was supposed to solve the issue https://github.com/OpenFAST/openfast_toolbox/issues/13 was closed, but I think this specific change is meaningful.

This will not affect the usual local developer install. This way openfast_toolbox can be integrated more easily into other projects.